### PR TITLE
Fixes flutter issue #14203 for this package

### DIFF
--- a/lib/src/with_keep_keyboard_popup_menu.dart
+++ b/lib/src/with_keep_keyboard_popup_menu.dart
@@ -245,8 +245,6 @@ class WithKeepKeyboardPopupMenuState extends State<WithKeepKeyboardPopupMenu> {
       await _menuKey.currentState.hideMenu();
       _entry.remove();
       popupState = PopupMenuState.CLOSED;
-      if (mounted)
-        setState((){});
     }
   }
 }

--- a/lib/src/with_keep_keyboard_popup_menu.dart
+++ b/lib/src/with_keep_keyboard_popup_menu.dart
@@ -246,6 +246,8 @@ class WithKeepKeyboardPopupMenuState extends State<WithKeepKeyboardPopupMenu> {
       await _menuKey.currentState.hideMenu();
       _entry.remove();
       popupState = PopupMenuState.CLOSED;
+      if (mounted)
+        setState((){});
     }
   }
 }

--- a/lib/src/with_keep_keyboard_popup_menu.dart
+++ b/lib/src/with_keep_keyboard_popup_menu.dart
@@ -111,6 +111,12 @@ class WithKeepKeyboardPopupMenuState extends State<WithKeepKeyboardPopupMenu> {
   PopupMenuState popupState = PopupMenuState.CLOSED;
 
   @override
+  void dispose() {
+    super.dispose();
+    closePopupMenu();
+  }
+
+  @override
   Widget build(BuildContext context) {
     bool preventPop = popupState == PopupMenuState.OPENED ||
         popupState == PopupMenuState.OPENING;

--- a/lib/src/with_keep_keyboard_popup_menu.dart
+++ b/lib/src/with_keep_keyboard_popup_menu.dart
@@ -112,21 +112,30 @@ class WithKeepKeyboardPopupMenuState extends State<WithKeepKeyboardPopupMenu> {
 
   @override
   Widget build(BuildContext context) {
-    return WillPopScope(
-      onWillPop: () async {
-        if (popupState == PopupMenuState.OPENED ||
-            popupState == PopupMenuState.OPENING) {
-          closePopupMenu();
-          return false;
-        } else {
-          return true;
-        }
-      },
-      child: Container(
-        key: _childKey,
-        child: widget.childBuilder(context, openPopupMenu),
-      ),
+    bool preventPop = popupState == PopupMenuState.OPENED ||
+        popupState == PopupMenuState.OPENING;
+
+    Container mainView = Container(
+      key: _childKey,
+      child: widget.childBuilder(context, openPopupMenu),
     );
+    if (preventPop) {
+      return WillPopScope(
+          onWillPop: () async {
+            if (popupState == PopupMenuState.OPENED ||
+                popupState == PopupMenuState.OPENING) {
+              closePopupMenu();
+              return false;
+            } else {
+              return true;
+            }
+          },
+          child: mainView
+      );
+    }
+    else {
+      return mainView;
+    }
   }
 
   Rect _getChildRect() {

--- a/lib/src/with_keep_keyboard_popup_menu.dart
+++ b/lib/src/with_keep_keyboard_popup_menu.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
 import 'dart:math';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 
 import 'animated_popup_menu.dart';
 import 'keep_keyboard_popup_menu_item.dart';
@@ -118,14 +120,11 @@ class WithKeepKeyboardPopupMenuState extends State<WithKeepKeyboardPopupMenu> {
 
   @override
   Widget build(BuildContext context) {
-    bool preventPop = popupState == PopupMenuState.OPENED ||
-        popupState == PopupMenuState.OPENING;
-
     Container mainView = Container(
       key: _childKey,
       child: widget.childBuilder(context, openPopupMenu),
     );
-    if (preventPop) {
+    if (kIsWeb || !Platform.isIOS) {
       return WillPopScope(
           onWillPop: () async {
             if (popupState == PopupMenuState.OPENED ||


### PR DESCRIPTION
Currently any widget that implements WillPopScope prevents swipe back on iOS which is a crucial navigation feature:
https://github.com/flutter/flutter/issues/14203

My PR proposes not to use WillPopScope for iOS and instead to hide the menu, should the user use the swipe back navigation. This PR hasn't been tested on web, I do recommend testing it before a merge because I'm using the dart:io package which is not compatible with web. I think it's fine but best to check.