### PR TITLE
Ignore all gestures below popup (scroll, long press)

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -66,7 +66,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   plugin_platform_interface:
     dependency: transitive
     description:

--- a/lib/src/percentage_size.dart
+++ b/lib/src/percentage_size.dart
@@ -74,7 +74,7 @@ class _RenderPercentageSize extends RenderAligningShiftedBox {
       rect,
       super.paint,
       clipBehavior: _clipBehavior,
-      oldLayer: _clipRectLayer,
+      // oldLayer: _clipRectLayer, // fix error on flutter 2.5+
     );
   }
 }

--- a/lib/src/with_keep_keyboard_popup_menu.dart
+++ b/lib/src/with_keep_keyboard_popup_menu.dart
@@ -210,15 +210,10 @@ class WithKeepKeyboardPopupMenuState extends State<WithKeepKeyboardPopupMenu> {
         return Stack(
           children: [
             Positioned.fill(
-              child: GestureDetector(
-                onTap: closePopupMenu,
-                onLongPress: () {},
-                onVerticalDragStart: (_) {},
-                onVerticalDragDown: (_) {},
-                onVerticalDragUpdate: (_) {},
-                onHorizontalDragStart: (_) {},
-                onHorizontalDragDown: (_) {},
-                onHorizontalDragUpdate: (_) {},
+              child: IgnorePointer(
+                child: GestureDetector(
+                  onTap: closePopupMenu,
+                ),
               ),
             ),
             CustomSingleChildLayout(

--- a/lib/src/with_keep_keyboard_popup_menu.dart
+++ b/lib/src/with_keep_keyboard_popup_menu.dart
@@ -210,7 +210,7 @@ class WithKeepKeyboardPopupMenuState extends State<WithKeepKeyboardPopupMenu> {
         return Stack(
           children: [
             Positioned.fill(
-              child: IgnorePointer(
+              child: AbsorbPointer(
                 child: GestureDetector(
                   onTap: closePopupMenu,
                 ),

--- a/lib/src/with_keep_keyboard_popup_menu.dart
+++ b/lib/src/with_keep_keyboard_popup_menu.dart
@@ -212,7 +212,13 @@ class WithKeepKeyboardPopupMenuState extends State<WithKeepKeyboardPopupMenu> {
             Positioned.fill(
               child: GestureDetector(
                 onTap: closePopupMenu,
-                onTapDown: (_){},
+                onLongPress: () {},
+                onVerticalDragStart: (_) {},
+                onVerticalDragDown: (_) {},
+                onVerticalDragUpdate: (_) {},
+                onHorizontalDragStart: (_) {},
+                onHorizontalDragDown: (_) {},
+                onHorizontalDragUpdate: (_) {},
               ),
             ),
             CustomSingleChildLayout(

--- a/lib/src/with_keep_keyboard_popup_menu.dart
+++ b/lib/src/with_keep_keyboard_popup_menu.dart
@@ -212,6 +212,7 @@ class WithKeepKeyboardPopupMenuState extends State<WithKeepKeyboardPopupMenu> {
             Positioned.fill(
               child: GestureDetector(
                 onTap: closePopupMenu,
+                onTapDown: (_){},
               ),
             ),
             CustomSingleChildLayout(

--- a/lib/src/with_keep_keyboard_popup_menu.dart
+++ b/lib/src/with_keep_keyboard_popup_menu.dart
@@ -210,10 +210,16 @@ class WithKeepKeyboardPopupMenuState extends State<WithKeepKeyboardPopupMenu> {
         return Stack(
           children: [
             Positioned.fill(
-              child: AbsorbPointer(
-                child: GestureDetector(
-                  onTap: closePopupMenu,
-                ),
+              child: GestureDetector(
+                onTap: closePopupMenu,
+                onTapDown: (_) {},
+                onLongPress: () {},
+                onVerticalDragStart: (_) {},
+                onVerticalDragDown: (_) {},
+                onVerticalDragUpdate: (_) {},
+                onHorizontalDragStart: (_) {},
+                onHorizontalDragDown: (_) {},
+                onHorizontalDragUpdate: (_) {},
               ),
             ),
             CustomSingleChildLayout(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -59,7 +59,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   plugin_platform_interface:
     dependency: transitive
     description:


### PR DESCRIPTION
When popup menu showed on list item, then you can scroll list below, or switch tabs by swipe, etc. PR fix this. 